### PR TITLE
initial broken search fun

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -28,23 +28,28 @@ module RackspaceIptables
     def search_add_iptables_rules(search_str, chain, rules_to_add, weight = 50, comment = search_str)
       if !Chef::Config['solo']
         rules = {}
+        server_ips = []
         nodes = search('node', search_str) || []
         nodes.map! do |member|
-          server_ip = begin
-            if member.attribute?('cloud')
-              if node.attribute?('cloud') && (member['cloud']['provider'] == node['cloud']['provider'])
-                member['cloud']['local_ipv4']
-              else
-                member['cloud']['public_ipv4']
+          if member.attribute?('cloud')
+            if member['cloud']['provider'] == ('rackspace' || 'openstack')
+              if member['cloud'].attribute?('local_ipv4')
+                server_ips.push(member['cloud']['local_ipv4']) unless member['cloud']['local_ipv4'].nil?
+              elsif member['cloud'].attribute?('public_ipv4')
+                server_ips.push(member['cloud']['public_ipv4']) unless member['cloud']['public_ipv4'].nil?
               end
-            else
-              member['ipaddress']
+            end
+          elsif
+            if member.attribute?('ipaddress')
+              server_ips.push(member['ipaddress']) unless member['ipaddress'].nil?
             end
           end
           # when passing a single rule, user may use a string instead of an array
           rules_to_add = [rules_to_add] if rules_to_add.class == String
           rules_to_add.each do |rule|
-            rules["-s #{server_ip}/32 " << rule] = { comment: comment, weight: weight }
+            server_ips.each do |server_ip|
+              rules["-s #{server_ip}/32 " << rule] = { comment: comment, weight: weight }
+            end
           end
         end
         rules.each { |rule, val| node.default['rackspace_iptables']['config']['chains'][chain][rule] = val }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache 2.0'
 description      'Installs/Configures rackspace_iptables'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.3.0'
 
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
This rewrite is for the following reasons
1.  before, if cloud was defined it would pull in the local_ipv4 at all times, what happens if we want public_ipv4 or just the simple ipaddress?
2. if the node was nil then it would break the chef run on iptables load

This intends to fix that by adding all the iptables rules and since they are attributes (hash/dict) they will 'auto compress'.

for some reason the .nil? always blocks adding the ip address.... so it's not ready for merge
