### PR TITLE
Change search_add_iptables_rules syntax to make it chef-zero compatible

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,7 +26,7 @@ module RackspaceIptables
     end
 
     def search_add_iptables_rules(search_str, chain, rules_to_add, weight = 50, comment = search_str)
-      search_str = search_str << " AND -name:#{node.name}"
+      search_str = "NOT name:#{node.name} AND (" << search_str << ')'
       if !Chef::Config['solo']
         rules = {}
         nodes = search('node', search_str) || []


### PR DESCRIPTION
the `-name` [syntax is not working with chef-zero](https://github.com/opscode/chef-zero/issues/100). 

It's definitely a blocker, as if we want to use test-kitchen + chef-zero + serverspec we are not able to test rules generated by rackspace_iptables.

I've not used `AND NOT` simply because [chef documentation](https://docs.getchef.com/essentials_search.html#operators) says it might return a syntax error.

I've run the unit test before to do the PR : 

```
Finished in 3.92 seconds (files took 2.14 seconds to load)
10 examples, 0 failures

ChefSpec Coverage report generated...

  Total Resources:   7
  Touched Resources: 5
  Touch Coverage:    71.43%

Untouched Resources:

  service[firewalld]                 rackspace_iptables/recipes/default.rb:35
  log[run the iptables template last]   rackspace_iptables/recipes/default.rb:43
```
