### PR TITLE
Change search_add_iptables_rules syntax to make it chef-zero compatible V2

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,7 +26,7 @@ module RackspaceIptables
     end
 
     def search_add_iptables_rules(search_str, chain, rules_to_add, weight = 50, comment = search_str)
-      search_str = search_str << " AND -name:#{node.name}"
+      search_str = search_str << " AND NOT name:#{node.name}"
       if !Chef::Config['solo']
         rules = {}
         nodes = search('node', search_str) || []


### PR DESCRIPTION
https://github.com/rackspace-cookbooks/rackspace_iptables/pull/22 worked but was introducing other bugs. This PR should work in all cases.
