### PR TITLE
Fix for Ubuntu 14.10 support which moves to netfilter

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,10 @@ when 'debian'
   end
   package_name = 'iptables-persistent'
   service_name = 'iptables-persistent'
+  if node['platform_version'].to_f >= 14.10
+    service_name = 'netfilter-persistent'
+  end
+
   rules_file = '/etc/iptables/rules.v4'
 when 'rhel'
   package_name = nil


### PR DESCRIPTION
This is needed in the newest version of Ubuntu 14.10, which moves to iptables-persistent filters within netfilter-persistent. The service to maintain is now the latter, netfilter-persistent.